### PR TITLE
feat: display qr codes in library and swipe-to-delete

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/cmput301w23t40/capturetheqr/LibraryActivity.java
+++ b/app/src/main/java/com/cmput301w23t40/capturetheqr/LibraryActivity.java
@@ -1,14 +1,29 @@
 package com.cmput301w23t40.capturetheqr;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
+import android.widget.ArrayAdapter;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This class defines the UI page for the QR Code Library
  */
 public class LibraryActivity extends AppCompatActivity {
+
+    RecyclerView qrCodeView;
+    ArrayList<QRCode> qrCodeDataList;
+    QRCodeList qrCodeList;
+
     /**
      * override Activity onCreate method
      * @param savedInstanceState
@@ -19,6 +34,47 @@ public class LibraryActivity extends AppCompatActivity {
         setContentView(R.layout.activity_library);
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        // Display list of QR Codes
+        qrCodeView = findViewById(R.id.qrcode_list);
+
+        LinearLayoutManager manager = new LinearLayoutManager(this);
+        qrCodeView.setLayoutManager(manager);
+
+        // TODO: using fake data rn (waiting for Firestore integration)
+        // TODO: right now, only qr code name is being displayed
+        qrCodeDataList = new ArrayList<>();
+        ArrayList<String> visFake = new ArrayList<String>(Arrays.asList("vis", "fake", "list"));
+
+        QRCode qr1 = new QRCode("fakeHash", "name1", visFake, 10);
+        QRCode qr2 = new QRCode("fakeHash", "name2", visFake, 20);
+        qrCodeDataList.addAll(Arrays.asList(qr1, qr2));
+        qrCodeList = new QRCodeList(this, qrCodeDataList);
+
+        qrCodeView.setAdapter(qrCodeList);
+
+        /* The ItemTouchHelper swipe-to-delete functionality below was copied (and altered) from:
+            author: https://auth.geeksforgeeks.org/user/chaitanyamunje
+            url: https://www.geeksforgeeks.org/swipe-to-delete-and-undo-in-android-recyclerview/
+            last updated: Oct 5, 2021
+            altered: removed Snackbar functionality that allows for undoing the deletion and changed the onMove so that it calls onSwiped (entry is
+                     deleted even when the user only partially swipes the item)
+        */
+        new ItemTouchHelper(new ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.RIGHT) {
+            @Override
+            public boolean onMove(@NonNull RecyclerView cityList, @NonNull RecyclerView.ViewHolder viewHolder, @NonNull RecyclerView.ViewHolder target) {
+                onSwiped(viewHolder, 1);
+                return false;
+            }
+
+            @Override
+            public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
+                // TODO: delete via Firestore (so changes are persistent)
+                qrCodeDataList.remove(viewHolder.getBindingAdapterPosition());
+                qrCodeList.notifyDataSetChanged();
+
+            }
+        }).attachToRecyclerView(qrCodeView);
     }
 
     /**

--- a/app/src/main/java/com/cmput301w23t40/capturetheqr/QRCodeList.java
+++ b/app/src/main/java/com/cmput301w23t40/capturetheqr/QRCodeList.java
@@ -1,0 +1,58 @@
+package com.cmput301w23t40.capturetheqr;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+
+import java.util.ArrayList;
+
+public class QRCodeList extends RecyclerView.Adapter<QRCodeList.RecyclerViewHolder>{
+
+    private ArrayList<QRCode> qrCodes;
+    private Context context;
+
+    public QRCodeList(Context context, ArrayList<QRCode> qrCodes){
+        this.qrCodes = qrCodes;
+        this.context = context;
+    }
+
+
+    /* Adapted code from the following resource for the swipe-to-delete functionality:
+            author: https://auth.geeksforgeeks.org/user/chaitanyamunje
+            url: https://www.geeksforgeeks.org/swipe-to-delete-and-undo-in-android-recyclerview/
+            last updated: Oct 5, 2021
+    */
+    public class RecyclerViewHolder extends RecyclerView.ViewHolder {
+        private TextView qrCodeName;
+
+        public RecyclerViewHolder(@NonNull View itemView) {
+            super(itemView);
+            qrCodeName = itemView.findViewById(R.id.txtvw_qrcodeName);
+        }
+    }
+
+    @NonNull
+    @Override
+    public RecyclerViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        View v = inflater.inflate(R.layout.library_content, parent, false);
+        return new RecyclerViewHolder(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerViewHolder holder, int position) {
+        QRCode code = qrCodes.get(position);
+        holder.qrCodeName.setText(code.getCodeName());
+    }
+
+    @Override
+    public int getItemCount() {
+        return qrCodes.size();
+    }
+}

--- a/app/src/main/java/com/cmput301w23t40/capturetheqr/QRCodeList.java
+++ b/app/src/main/java/com/cmput301w23t40/capturetheqr/QRCodeList.java
@@ -12,6 +12,10 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 
+/**
+ * This class keeps track of the list of QR Code objects
+ */
+
 public class QRCodeList extends RecyclerView.Adapter<QRCodeList.RecyclerViewHolder>{
 
     private ArrayList<QRCode> qrCodes;
@@ -28,6 +32,9 @@ public class QRCodeList extends RecyclerView.Adapter<QRCodeList.RecyclerViewHold
             url: https://www.geeksforgeeks.org/swipe-to-delete-and-undo-in-android-recyclerview/
             last updated: Oct 5, 2021
     */
+    /**
+     * This class keeps track of and deletes the UI element for displaying QR Codes
+     */
     public class RecyclerViewHolder extends RecyclerView.ViewHolder {
         private TextView qrCodeName;
 
@@ -37,6 +44,12 @@ public class QRCodeList extends RecyclerView.Adapter<QRCodeList.RecyclerViewHold
         }
     }
 
+    /**
+     * This inflates card layout items for the View
+     * @param parent
+     * @param viewType
+     * @return RecylerViewHolder
+     */
     @NonNull
     @Override
     public RecyclerViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -45,12 +58,21 @@ public class QRCodeList extends RecyclerView.Adapter<QRCodeList.RecyclerViewHold
         return new RecyclerViewHolder(v);
     }
 
+    /**
+     * This sets up the item's content in given position used by the View
+     * @param holder
+     * @param position
+     */
     @Override
     public void onBindViewHolder(@NonNull RecyclerViewHolder holder, int position) {
         QRCode code = qrCodes.get(position);
         holder.qrCodeName.setText(code.getCodeName());
     }
 
+    /**
+     * This returns the length of the RecyclerView
+     * @return size of qr code list
+     */
     @Override
     public int getItemCount() {
         return qrCodes.size();

--- a/app/src/main/res/layout/activity_library.xml
+++ b/app/src/main/res/layout/activity_library.xml
@@ -6,19 +6,9 @@
     android:layout_height="match_parent"
     tools:context=".LibraryActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/txtvw_mapFillerText"
-        android:text="@string/library_page_main_txt"
-        android:textSize="35dp"
-        android:fontFamily="sans-serif"
-        android:textColor="@color/med_blue"
-        android:textStyle="bold|italic"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.075" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/qrcode_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/library_content.xml
+++ b/app/src/main/res/layout/library_content.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/txtvw_qrcodeName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="20dp"
+        android:textColor="@color/med_blue"
+        android:text="QR Code Name"
+        android:textSize="30sp">
+    </TextView>
+
+</LinearLayout>
+
+


### PR DESCRIPTION
### Description:
This PR setups up the basic UI of the QR library (list of QR Code Names for now) and has swipe-to-delete functionality. Note, this only deals with the frontend aspect so Firestone integration to get current data and then delete it needs to be added (right now I have fake qr code objects)

### Issue: frontend aspect of #4 and #2 (not done since we probably want to display more qr code stuff to the user)

### Screenshots:
<img width="217" alt="Screen Shot 2023-02-23 at 1 02 48 PM" src="https://user-images.githubusercontent.com/70451233/221017419-395698b1-89e7-40a7-99b0-a047841bb213.png">
<img width="215" alt="Screen Shot 2023-02-23 at 1 02 58 PM" src="https://user-images.githubusercontent.com/70451233/221017451-2ea5dcb6-f11d-4428-8bbd-132b704af0ff.png"> (after swiping name1)
