### PR TITLE
fixed bug in scoring system

### DIFF
--- a/app/src/main/java/com/cmput301w23t40/capturetheqr/QRAnalyzer.java
+++ b/app/src/main/java/com/cmput301w23t40/capturetheqr/QRAnalyzer.java
@@ -101,10 +101,11 @@ public class QRAnalyzer {
      */
     public static int generateScore(String inputString) {
 
+        //get the consecutive repeats in the input string
         Map<Character, Integer> map = getConsecutiveRepeats(inputString);
 
-        // init the sum
-        int sum = 0;
+        // init the sum to the number of isolated 0's
+        int sum = countIsolatedZeros(inputString);
 
         // loop through the map
         for (Map.Entry<Character, Integer> entry : map.entrySet()) {
@@ -163,6 +164,21 @@ public class QRAnalyzer {
             occurrences.put(currentChar, count);
 
         return occurrences;
+    }
+
+    /**
+     * This function will count isolated 0's in a string
+     * @param inputString the input string to parse throught
+     * @return the number of isolated 0's in the string
+     */
+    public static int countIsolatedZeros(String inputString) {
+        int count = 0;
+
+        for (int i = 0; i < inputString.length(); i++)
+            if (inputString.charAt(i) == '0' && (i == 0 || inputString.charAt(i-1) != '0') && (i == inputString.length()-1 || inputString.charAt(i+1) != '0'))
+                count++;
+
+        return count;
     }
 
     /**

--- a/app/src/test/java/com/cmput301w23t40/capturetheqr/QRAnalyzerTest.java
+++ b/app/src/test/java/com/cmput301w23t40/capturetheqr/QRAnalyzerTest.java
@@ -34,6 +34,12 @@ public class QRAnalyzerTest {
     }
 
     @Test
+    void testSingleZero(){
+        assertEquals(QRAnalyzer.countIsolatedZeros("0"),1);
+        assertEquals(QRAnalyzer.generateScore("0"),1);
+    }
+
+    @Test
     void testName(){
         String s = QRAnalyzer.generateHashValue("BFG5DGW54");
         assertEquals(QRAnalyzer.generateName(s),"cool FroLoUltraSpectralShark");

--- a/app/src/test/java/com/cmput301w23t40/capturetheqr/QRAnalyzerTest.java
+++ b/app/src/test/java/com/cmput301w23t40/capturetheqr/QRAnalyzerTest.java
@@ -15,12 +15,22 @@ public class QRAnalyzerTest {
     @Test
     void testScore(){
         String s = QRAnalyzer.generateHashValue("BFG5DGW54");
-        assertEquals(QRAnalyzer.generateScore(s),111);
+        assertEquals(QRAnalyzer.generateScore(s),115);
     }
 
     @Test
     void testScoreZeros(){
         assertEquals(QRAnalyzer.generateScore("0000"),8000);
+    }
+
+    @Test
+    void testNoIsolatedZeros(){
+        assertEquals(QRAnalyzer.countIsolatedZeros("0000"),0);
+    }
+
+    @Test
+    void testIsolatedZeros(){
+        assertEquals(QRAnalyzer.countIsolatedZeros("01203400560"),3);
     }
 
     @Test


### PR DESCRIPTION
# 🐛= 🔨 (bug squashed)

There was a bug #86 in the scoring system that didn't handle isolated 0's and giving a single point for them. This is now fixed and additional unit tests have been added